### PR TITLE
#65 Additional configuration option in Robots.txt app

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ query {
                 userAgent
                 allow
                 disallow
+                crawlDelay
             }
             sitemap
             cachecontrol

--- a/src/main/resources/guillotine/types/index.js
+++ b/src/main/resources/guillotine/types/index.js
@@ -30,6 +30,9 @@ exports.createRobotsRuleType = function (graphQL) {
             },
             disallow: {
                 type: graphQL.list(graphQL.GraphQLString),
+            },
+            crawlDelay: {
+                type: graphQL.GraphQLInt,
             }
         }
     };

--- a/src/main/resources/lib/robots.js
+++ b/src/main/resources/lib/robots.js
@@ -52,11 +52,29 @@ exports.resolveSourceConfig = function (project, branch, siteKey) {
 };
 
 function createRule(group) {
-    return {
+    const rule = {
         userAgent: utilLib.forceArray(group.userAgent) || DEFAULT_RULE.userAgent,
         allow: utilLib.forceArray(group.allow),
         disallow: utilLib.forceArray(group.disallow)
     };
+
+    const crawlDelay = parseCrawlDelay(group.crawlDelay);
+    if (crawlDelay !== null) {
+        rule.crawlDelay = crawlDelay;
+    }
+
+    return rule;
+}
+
+function parseCrawlDelay(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    const num = Number(value);
+    if (!isFinite(num) || num <= 0) {
+        return null;
+    }
+    return Math.floor(num);
 }
 
 function writeRule(rule) {
@@ -65,6 +83,10 @@ function writeRule(rule) {
     utilLib.forceArray(rule.userAgent).forEach(function (userAgent) {
         result += `User-agent: ${userAgent}\n`;
     });
+
+    if (rule.crawlDelay !== null && rule.crawlDelay !== undefined) {
+        result += `Crawl-delay: ${rule.crawlDelay}\n`;
+    }
 
     utilLib.forceArray(rule.allow).forEach(function (allow) {
         result += `Allow: ${allow}\n`;

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -19,6 +19,15 @@
                     <occurrences minimum="0" maximum="0" />
                     <default> </default>
                 </input>
+                <input name="crawlDelay" type="Long">
+                    <label>Crawl-delay</label>
+                    <occurrences minimum="0" maximum="1"/>
+                    <config>
+                        <min>0</min>
+                        <max>86400</max>
+                    </config>
+                    <help-text>Optional crawl delay in seconds for this user-agent</help-text>
+                </input>
             </items>
         </item-set>
         <input name="sitemap" type="TextLine">


### PR DESCRIPTION
Closes #65.

Adds an optional `Crawl-delay` value per user-agent rule.

### Changes
- **UI:** new optional `crawlDelay` `Long` input on the user-agent rule item-set in `site/site.xml`, with `min=0` / `max=86400` validation and a help text.
- **Guillotine:** `crawlDelay` field exposed on the `RobotsRule` GraphQL type (`GraphQLInt`).
- **Renderer (`lib/robots.js`):** emits `Crawl-delay: <n>` between `User-agent:` and the `Allow`/`Disallow` lines when set to a positive integer; non-numeric, null, empty, and zero values are skipped so output is unchanged for content that doesn't use the new field.
- **README:** documents the new field in the GraphQL example.

### Example
```
User-agent: bingbot
Crawl-delay: 10
Disallow: /admin
```

### Backwards compatibility
The field is optional. Existing content (no `crawlDelay` value) produces byte-identical output to before this change — verified by replaying the renderer against the original implementation across several config shapes.