### PR TITLE
Bump version to 5.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = robotstxt
 appName = com.enonic.app.robotstxt
 xpVersion = 8.0.0-B4
-version=4.1.1-SNAPSHOT
+version=5.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Branch `master` now tracks the next major (XP 8) line: bump `version` from `4.1.1-SNAPSHOT` to `5.0.0-SNAPSHOT`.
- Add `releaseBranch:` config to `enonic-gradle.yml` listing both `master` and `4.x`, so pushes to either branch are recognized by the shared release-tools workflow as release-branch builds.

The companion `4.x` maintenance branch was created at SHA `00b2b8f` (the post-`v4.1.0` "Updated to next SNAPSHOT version" commit), preserving `version=4.1.1-SNAPSHOT` on the XP 7 line. A separate PR against `4.x` adds the same `releaseBranch:` block there.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: `./gradlew clean build` from master is green
- [ ] After merge of the `4.x` companion PR: a CI run on `4.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)