### PR TITLE
Add release-branch CI config for 4.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `4.x`. This is required so pushes to the `4.x` XP 7 maintenance branch are recognized as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).
- No version bump and no other changes on `4.x` — this branch keeps `version=4.1.1-SNAPSHOT` for the XP 7 line.

Companion PR on master (#69) bumps master to `5.0.0-SNAPSHOT` and adds the same `releaseBranch:` block there.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: a CI run on `4.x` classifies it as a release branch
- [ ] `gradle.properties` on `4.x` remains at `version=4.1.1-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)